### PR TITLE
Include client script in installation, and README updates

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -5,8 +5,9 @@ desktop = xdg-open-server.desktop
 applicationdir = $(prefix)/share/applications
 autostartdir = $(sysconfdir)/xdg/autostart
 
-application_DATA = $(desktop)
-autostart_DATA = $(desktop)
+dist_application_DATA = $(desktop)
+dist_autostart_DATA = $(desktop)
+dist_pkgdata_DATA = $(shell find scripts/ -name "*.sh")
 
 bin_PROGRAMS = xdg-open-server
 
@@ -19,3 +20,6 @@ xdg_open_server_LDFLAGS = \
 	-lpthread
 
 CLEANFILES += $(bin_PROGRAMS)
+
+install-data-hook:
+	chmod +x $(DESTDIR)$(pkgdatadir)/*.sh

--- a/PKGBUILD
+++ b/PKGBUILD
@@ -1,10 +1,11 @@
 pkgname=xdg-open-server
-pkgver=1.0
+pkgver=1.1
 pkgrel=1
 pkgdesc="xdg-open portal for Docker containers"
 arch=('i686' 'x86_64')
 license=('MIT')
 depends=('libx11' 'xdg-utils')
+optdepends=('socat: xdg-open.sh client script support')
 source=('git://github.com/kitsunyan/xdg-open-server.git')
 sha256sums=('SKIP')
 

--- a/README.md
+++ b/README.md
@@ -12,15 +12,23 @@ Pacman-based distributions users can make a package using provided `PKGBUILD` fi
 
 The application will be started with your XDG-compliant desktop environment.
 
-## Using with Docker Containers
-
-The following xdg-open script allows you to send data to your server:
-
-```shell
-#!/bin/sh
-echo "$@" | socat - UNIX-CLIENT:/run/user/$UID/xdg-open-server/socket`echo $DISPLAY | sed -r 's/\\\\/\\\\\\\\/g' | sed -r 's/:/\\\\:/g'`
+To automatically start the application in i3, add the following line to your to your `~/.i3/config`:
+```
+exec --no-startup-id xdg-open-server &
 ```
 
-You can put this script to `/usr/local/bin` directory of your Docker container.
+## Using with Docker Containers
 
-You should also share your socket directory to Docker container using `-v /run/user/$UID/xdg-open-server:/run/user/$UID/xdg-open-server:ro`.
+A client script allowing you to send data to your server is installed at `$prefix/share/xdg-open-server/xdg-open.sh` (`/usr/share/xdg-open-server/xdg-open.sh` if installing from `PKGBUILD`).  Install this script in the `/usr/local/bin` directory of your Docker image.  The client script depends on the `socat` utility.
+
+You should also share your socket directory to Docker container using `-v "${XDG_RUNTIME_DIR}/xdg-open-server:${XDG_RUNTIME_DIR}/xdg-open-server:ro"`.  If the user ID in your container environment differs from your own user ID, adjust the mount point accordingly.
+
+If you are unable to alter your Docker image, you can mount the client script and `socat` binary into the container as shown below:
+
+```
+docker run --name my_container \
+	-v "${XDG_RUNTIME_DIR}/xdg-open-server:${XDG_RUNTIME_DIR}/xdg-open-server:ro" \
+	-v /usr/share/xdg-open-server/xdg-open.sh:/usr/bin/xdg-open:ro \
+	-v /bin/socat:/bin/socat \
+    my_image
+```

--- a/configure.ac
+++ b/configure.ac
@@ -1,4 +1,4 @@
-AC_INIT([xdg-open-server],[1.0])
+AC_INIT([xdg-open-server],[1.1])
 
 AC_CONFIG_FILES([Makefile])
 AC_PREFIX_DEFAULT([/usr/local])

--- a/scripts/xdg-open.sh
+++ b/scripts/xdg-open.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+echo "$@" | socat - "UNIX-CLIENT:/run/user/$(id --user)/xdg-open-server/socket$(echo "${DISPLAY}" | sed -r 's/\\/\\\\/g' | sed -r 's/:/\\:/g')"


### PR DESCRIPTION
Hi, thank you for this utility!  I've found it very useful.

I made a couple edits for your consideration:
- Include the `xdg-open.sh` client script in the installation
- In `xdg-open.sh`, derive user ID from `id --user` rather than `$UID` shell variable (also linted the script using `shellcheck`)
- Added `socat` as an optional dependency in the `PKGBUILD`
- Expanded the Docker example in the README, and a note for i3wm users on auto-starting the application
- Updated so `xdg-open-server.desktop` will be included by `make dist`

Would you consider putting this on the AUR?